### PR TITLE
Make the new docker setup work on linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       TEST_STREAM_NAME: test_rabblerouser_stream
     command: sleep 2147483647 # Sleep forever, we'll shell into the container later
     stdin_open: true
+    user: $UID
     tty: true
   db:
     image: postgres


### PR DESCRIPTION
My user (uid 1000) gets mapped to the user created when node is installed in the container (uid 1000), so if I run as `rabblerouser` I can't `npm install` or anything useful because the files in the volume mount at `/app` are owned by my user on the host. This fix for #152 lets me override the default user I'm going to run as, and defaults to the "rabblerouser" user if $UID is not explicitly passed to `./go.sh`.

<!---
@huboard:{"order":22.02531332799966,"milestone_order":151,"custom_state":"archived"}
-->
