### PR TITLE
Build from base docker image and don't copy in node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git/
 e2e/
+backend/node_modules/
+frontend/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,1 @@
-FROM node:6.10-alpine
-
-WORKDIR /app
-COPY . /app
-
-RUN adduser -D rabblerouser
-RUN chown -R rabblerouser /app
-USER rabblerouser
-
-RUN npm install
-
-ENV NODE_ENV production
-EXPOSE 3000
-CMD npm start
+FROM rabblerouser/node-base


### PR DESCRIPTION
Now using [this base image](https://hub.docker.com/r/rabblerouser/node-base/), from [this repo](https://github.com/rabblerouser/node-base-image).

This reduces copy-pasta effort as we add more services.

Also, don't mount `node_modules` from the host when building. Instead, install them fresh inside the container.

<!---
@huboard:{"order":4.0004,"milestone_order":164,"custom_state":"archived"}
-->
