### PR TITLE
Fix .travis.yml after_success to not run for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install: npm install
 script: ./go.sh npm test
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then bin/docker-build-and-deploy.sh; fi
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then bin/docker-build-and-deploy.sh; fi


### PR DESCRIPTION
Fix a bug in Travis scripts, where pull requests against the master branch trigger docker-build-and-deploy (which then hangs due to lack of Docker Hub credentials).

From Travis docs:

`TRAVIS_BRANCH:`

* for push builds, or builds not triggered by a pull request, this is the name of the branch.
* for builds triggered by a pull request this is the name of the branch targeted by the pull request.
* for builds triggered by a tag, this is the same as the name of the tag (TRAVIS_TAG).

<!---
@huboard:{"order":14.004200420014,"milestone_order":170,"custom_state":"archived"}
-->
