### PR TITLE
Added e2e curl dependency to dockerfile

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,8 +1,6 @@
 FROM node:6.10-alpine
 
 RUN apk add --no-cache curl
-ENTRYPOINT ["/usr/bin/curl"]
-
 RUN adduser -D rabblerouser
 
 WORKDIR /app

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,8 @@
 FROM node:6.10-alpine
+
+RUN apk add --no-cache curl
+ENTRYPOINT ["/usr/bin/curl"]
+
 RUN adduser -D rabblerouser
 
 WORKDIR /app


### PR DESCRIPTION
When running the e2e tests, we get the dependency failing on curl. So I added it to the docker file.

Unfortunately, due to Dockerhub not existing in my fork in isolation, I wasn't able to test this.
Having said that, it's a basic copy from another docker container:
https://hub.docker.com/r/byrnedo/alpine-curl/~/dockerfile/