### PR TITLE
Add ESLint directives to protect idiomatic Chai code.

### DIFF
--- a/backend/spec/unit/lib/inputValidatorSpec.js
+++ b/backend/spec/unit/lib/inputValidatorSpec.js
@@ -1,4 +1,13 @@
+// backend/spec/unit/lib/inputValidatorSpec.js
+// Unit tests for ‘inputValidator’ module.
+
 'use strict';
+
+// We disable the ‘no-unused-expressions’ ESLint rule in this file
+// because we use Chai `expect()….to.be.true` and similar
+// declarations. See <URL:http://www.chaijs.com/api/bdd/>
+// and <URL:https://eslint.org/docs/rules/no-unused-expressions>.
+/* eslint no-unused-expressions: "off" */
 
 const inputValidator = require('../../../src/lib/inputValidator');
 

--- a/backend/spec/unit/lib/memberValidatorSpec.js
+++ b/backend/spec/unit/lib/memberValidatorSpec.js
@@ -1,4 +1,13 @@
+// backend/spec/unit/lib/memberValidatorSpec.js
+// Unit tests for ‘memberValidator’ module.
+
 'use strict';
+
+// We disable the ‘no-unused-expressions’ ESLint rule in this file
+// because we use Chai `expect()….to.be.true` and similar
+// declarations. See <URL:http://www.chaijs.com/api/bdd/>
+// and <URL:https://eslint.org/docs/rules/no-unused-expressions>.
+/* eslint no-unused-expressions: "off" */
 
 const memberValidator = require('../../../src/lib/memberValidator');
 


### PR DESCRIPTION
The idiom in a test using Chai is to use `expect(…).to.be.true` and
similar; see <URL:http://www.chaijs.com/api/bdd/>. This looks like an
unused expression; disable that check for these test files.
